### PR TITLE
Restore animations and NFT text

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -29,10 +29,21 @@ const Home = () => {
             animate={{ y: 0, opacity: 1 }}
             transition={{ delay: 0.2, duration: 0.3 }}
           >
-            <h1 className="text-8xl font-bold tracking-widest text-transparent bg-clip-text bg-gradient-to-r from-gold to-aquamarine">
-              CHADWICK
-            </h1>
-            <span className="text-sm text-gold ml-2 mt-8">v2.0</span>
+            <div className="relative">
+              <h1 className={`text-8xl sm:text-9xl font-display font-bold text-gold ${isPulsing ? 'animate-pulse-quick' : ''}`}>
+                CHADWICK
+              </h1>
+              <span 
+                className={`absolute text-base sm:text-xl font-black text-nft-glow-fast ${isPulsing ? 'animate-pulse-quick' : ''}`}
+                style={{
+                  left: '100%',
+                  bottom: '0.1em',
+                  marginLeft: '0.5rem'
+                }}
+              >
+                NFT
+              </span>
+            </div>
           </motion.div>
 
           {/* Carousel in exact same center position */}


### PR DESCRIPTION
This PR restores the original animations and NFT text styling while maintaining GitHub Pages compatibility for image paths.

Changes:
- Restored pulsing animation
- Restored NFT text with glow effect
- Kept process.env.PUBLIC_URL for image paths

Tested locally and confirmed animations work.