### PR TITLE
Fix mobile alignment and Featured Work images

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -24,12 +24,12 @@ const Home = () => {
         <div className="h-full flex flex-col items-center justify-center relative">
           {/* CHADWICK text positioned higher */}
           <motion.div
-            className="absolute top-[40%] -translate-y-1/2 z-0 flex items-center justify-center w-full px-4 sm:px-0"
+            className="absolute sm:top-[40%] top-[35%] -translate-y-1/2 z-0 flex items-center justify-center w-full px-4 sm:px-0"
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             transition={{ delay: 0.2, duration: 0.3 }}
           >
-            <div className="relative">
+            <div className="relative transform sm:translate-x-0 -translate-x-[0.6rem]">
               <h1 className={`text-6xl xs:text-7xl sm:text-8xl md:text-9xl font-display font-bold text-gold ${isPulsing ? 'animate-pulse-quick' : ''}`}>
                 CHADWICK
               </h1>
@@ -49,7 +49,7 @@ const Home = () => {
 
           {/* Carousel in exact same center position */}
           <motion.div
-            className="absolute top-1/2 -translate-y-1/2 w-full flex items-center justify-center z-10 px-4 sm:px-0"
+            className="absolute sm:top-1/2 top-[45%] -translate-y-1/2 w-full flex items-center justify-center z-10 px-4 sm:px-0"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.4, duration: 0.3 }}


### PR DESCRIPTION
This PR improves the mobile experience while maintaining desktop layout:

- Adjusted title position on mobile to be closer to the top (35% vs 40%)
- Moved carousel up slightly on mobile (45% vs 50%)
- Added slight horizontal offset to title on mobile for better alignment
- Preserved desktop experience with sm: breakpoints
- Ensures Featured Work images are properly displayed