### PR TITLE
Fix image paths and mobile spacing

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -10,8 +10,8 @@ function Gallery() {
   // B&W photography collection
   const images = Array.from({ length: 17 }, (_, i) => ({
     id: i + 1,
-    src: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}.jpg`,
-    fullSrc: `${process.env.PUBLIC_URL}/images/bw/chadwicknft_photography-${i + 1}.jpg`,
+    src: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}${i < 2 ? '.JPG' : '.jpg'}`,
+    fullSrc: `${process.env.PUBLIC_URL}/images/bw/chadwicknft_photography-${i + 1}${i < 2 ? '.JPG' : '.jpg'}`,
     category: 'B&W',
     title: `Black & White ${i + 1}`,
   }));

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -24,7 +24,7 @@ const Home = () => {
         <div className="h-full flex flex-col items-center justify-center relative">
           {/* CHADWICK text positioned higher */}
           <motion.div
-            className="absolute sm:top-[40%] top-[35%] -translate-y-1/2 z-0 flex items-center justify-center w-full px-4 sm:px-0"
+            className="absolute sm:top-[40%] top-[25%] -translate-y-1/2 z-0 flex items-center justify-center w-full px-4 sm:px-0"
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             transition={{ delay: 0.2, duration: 0.3 }}
@@ -49,7 +49,7 @@ const Home = () => {
 
           {/* Carousel in exact same center position */}
           <motion.div
-            className="absolute sm:top-1/2 top-[45%] -translate-y-1/2 w-full flex items-center justify-center z-10 px-4 sm:px-0"
+            className="absolute sm:top-1/2 top-[35%] -translate-y-1/2 w-full flex items-center justify-center z-10 px-4 sm:px-0"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.4, duration: 0.3 }}


### PR DESCRIPTION
This PR addresses two issues:

1. Featured Work Images:
- Fixed image paths to handle .JPG vs .jpg extensions correctly
- Ensures thumbnails and full-size images are properly referenced

2. Mobile Spacing:
- Reduced space above title (25% from top vs 40% on desktop)
- Adjusted carousel position (35% from top vs 50% on desktop)
- Maintained desktop layout using sm: breakpoints

These changes should improve the mobile experience while keeping the desktop view unchanged.