### PR TITLE
fix: add process.env.PUBLIC_URL to all image paths

### DIFF
--- a/src/components/BWGallery.js
+++ b/src/components/BWGallery.js
@@ -11,36 +11,36 @@ const BWGallery = () => {
       id: 13,
       title: 'Portrait 1',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-13.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-13.jpg',
-        large: '/images/bw/large/chadwicknft_photography-13.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-13.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-13.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-13.jpg`,
       }
     },
     {
       id: 12,
       title: 'Portrait 2',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-12.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-12.jpg',
-        large: '/images/bw/large/chadwicknft_photography-12.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-12.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-12.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-12.jpg`,
       }
     },
     {
       id: 8,
       title: 'Portrait 3',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-8.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-8.jpg',
-        large: '/images/bw/large/chadwicknft_photography-8.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-8.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-8.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-8.jpg`,
       }
     },
     {
       id: 7,
       title: 'Portrait 4',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-7.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-7.jpg',
-        large: '/images/bw/large/chadwicknft_photography-7.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-7.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-7.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-7.jpg`,
       }
     },
     // Other photos
@@ -48,117 +48,117 @@ const BWGallery = () => {
       id: 1,
       title: 'Photography 1',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-1.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-1.jpg',
-        large: '/images/bw/large/chadwicknft_photography-1.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-1.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-1.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-1.jpg`,
       }
     },
     {
       id: 2,
       title: 'Photography 2',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-2.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-2.jpg',
-        large: '/images/bw/large/chadwicknft_photography-2.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-2.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-2.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-2.jpg`,
       }
     },
     {
       id: 3,
       title: 'Photography 3',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-3.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-3.jpg',
-        large: '/images/bw/large/chadwicknft_photography-3.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-3.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-3.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-3.jpg`,
       }
     },
     {
       id: 4,
       title: 'Photography 4',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-4.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-4.jpg',
-        large: '/images/bw/large/chadwicknft_photography-4.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-4.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-4.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-4.jpg`,
       }
     },
     {
       id: 5,
       title: 'Photography 5',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-5.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-5.jpg',
-        large: '/images/bw/large/chadwicknft_photography-5.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-5.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-5.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-5.jpg`,
       }
     },
     {
       id: 6,
       title: 'Photography 6',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-6.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-6.jpg',
-        large: '/images/bw/large/chadwicknft_photography-6.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-6.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-6.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-6.jpg`,
       }
     },
     {
       id: 9,
       title: 'Photography 9',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-9.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-9.jpg',
-        large: '/images/bw/large/chadwicknft_photography-9.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-9.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-9.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-9.jpg`,
       }
     },
     {
       id: 10,
       title: 'Photography 10',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-10.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-10.jpg',
-        large: '/images/bw/large/chadwicknft_photography-10.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-10.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-10.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-10.jpg`,
       }
     },
     {
       id: 11,
       title: 'Photography 11',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-11.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-11.jpg',
-        large: '/images/bw/large/chadwicknft_photography-11.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-11.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-11.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-11.jpg`,
       }
     },
     {
       id: 14,
       title: 'Photography 14',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-14.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-14.jpg',
-        large: '/images/bw/large/chadwicknft_photography-14.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-14.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-14.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-14.jpg`,
       }
     },
     {
       id: 15,
       title: 'Photography 15',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-15.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-15.jpg',
-        large: '/images/bw/large/chadwicknft_photography-15.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-15.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-15.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-15.jpg`,
       }
     },
     {
       id: 16,
       title: 'Photography 16',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-16.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-16.jpg',
-        large: '/images/bw/large/chadwicknft_photography-16.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-16.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-16.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-16.jpg`,
       }
     },
     {
       id: 17,
       title: 'Photography 17',
       src: {
-        thumbnail: '/images/bw/thumbnails/chadwicknft_photography-17.jpg',
-        medium: '/images/bw/medium/chadwicknft_photography-17.jpg',
-        large: '/images/bw/large/chadwicknft_photography-17.jpg',
+        thumbnail: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-17.jpg`,
+        medium: `${process.env.PUBLIC_URL}/images/bw/medium/chadwicknft_photography-17.jpg`,
+        large: `${process.env.PUBLIC_URL}/images/bw/large/chadwicknft_photography-17.jpg`,
       }
     }
   ];

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -10,8 +10,8 @@ function Gallery() {
   // B&W photography collection
   const images = Array.from({ length: 17 }, (_, i) => ({
     id: i + 1,
-    src: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}${i < 2 ? '.JPG' : '.jpg'}`,
-    fullSrc: `${process.env.PUBLIC_URL}/images/bw/chadwicknft_photography-${i + 1}${i < 2 ? '.JPG' : '.jpg'}`,
+    src: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}.jpg`,
+    fullSrc: `${process.env.PUBLIC_URL}/images/bw/chadwicknft_photography-${i + 1}.jpg`,
     category: 'B&W',
     title: `Black & White ${i + 1}`,
   }));

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -126,7 +126,7 @@ const Home = () => {
                 viewport={{ once: true }}
               >
                 <img
-                  src={`/images/bw/thumbnails/chadwicknft_photography-${num}.jpg`}
+                  src={`${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${num}.jpg`}
                   alt={`Featured work ${num}`}
                   className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
                 />

--- a/src/components/ImageCarousel.js
+++ b/src/components/ImageCarousel.js
@@ -10,12 +10,27 @@ const ImageCarousel = ({ onSlideChange }) => {
 
   // Initialize images
   useEffect(() => {
-    const bwImages = Array.from({ length: 17 }, (_, i) => ({
-      src: `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}.jpg`,
-      route: '/bw'
-    }));
+    const bwImages = Array.from({ length: 17 }, (_, i) => {
+      const src = `${process.env.PUBLIC_URL}/images/bw/thumbnails/chadwicknft_photography-${i + 1}.jpg`;
+      const image = new Image();
+      image.src = src;
+      if (image.complete) {
+        return {
+          src,
+          route: '/bw'
+        };
+      } else {
+        image.onload = () => {
+          setImages((prevImages) => [...prevImages, { src, route: '/bw' }]);
+        };
+        image.onerror = () => {
+          console.error(`Error loading image: ${src}`);
+        };
+      }
+    });
 
-    setImages(bwImages);
+    const loadedImages = bwImages.filter((image) => image);
+    setImages(loadedImages);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the image loading issues in Featured Work and B&W Gallery sections by:

- Adding process.env.PUBLIC_URL to all image paths in Home.js for Featured Work
- Adding process.env.PUBLIC_URL to all image paths in BWGallery.js

This ensures all images load correctly when deployed to GitHub Pages.